### PR TITLE
Initialize Next.js (App Router) + TypeScript starter with Tailwind CSS

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+out
+.env*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# AI FOMO
+
+AI FOMO is a Next.js (App Router) + TypeScript starter for tracking AI product signals. It ships with Tailwind CSS, example API routes, and seed data so you can deploy quickly on Vercel.
+
+## Getting Started
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view the app.
+
+## Project Structure
+
+- `app/` - App Router pages, layouts, and API routes.
+- `components/` - Shared UI components.
+- `lib/` - Static data and helper utilities.
+- `seed/` - Seed data used by the API routes.
+
+## API Routes
+
+- `GET /api/health` returns a simple health check.
+- `GET /api/seed` returns demo seed data.
+
+## Deployment
+
+This project is ready to deploy on Vercel. Push the repository to GitHub and import it into Vercel, or run:
+
+```bash
+npm run build
+npm run start
+```

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ status: "ok", timestamp: new Date().toISOString() });
+}

--- a/app/api/seed/route.ts
+++ b/app/api/seed/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+import { seedSignals } from "@/seed/signals";
+
+export async function GET() {
+  return NextResponse.json({ seeded: seedSignals.length, signals: seedSignals });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-white text-slate-900 antialiased;
+}
+
+main {
+  @apply min-h-screen bg-gradient-to-b from-white via-slate-50 to-slate-100;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "AI FOMO",
+  description: "Real-time AI signal watchlist with confidence tracking."
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,75 @@
+import { FeatureCard } from "@/components/FeatureCard";
+import { Footer } from "@/components/Footer";
+import { StatPill } from "@/components/StatPill";
+import { featureCards, heroHighlights, signalStats } from "@/lib/data";
+
+export default function Home() {
+  return (
+    <main className="px-6 py-12">
+      <section className="mx-auto flex max-w-5xl flex-col gap-10">
+        <div className="flex flex-col gap-6">
+          <span className="w-fit rounded-full bg-brand-50 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-brand-700">
+            AI Signal Hub
+          </span>
+          <div className="space-y-4">
+            <h1 className="text-4xl font-semibold text-slate-900 md:text-5xl">
+              Stay ahead of AI launches without the noise.
+            </h1>
+            <p className="max-w-2xl text-lg text-slate-600">
+              AI FOMO is a watchlist for teams tracking emerging AI products. Map
+              the signals, evaluate confidence, and share the "why" behind every
+              bet.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            {heroHighlights.map((item) => (
+              <span
+                key={item}
+                className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600"
+              >
+                {item}
+              </span>
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-3">
+            {signalStats.map((stat) => (
+              <StatPill key={stat.label} label={stat.label} value={stat.value} />
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-3">
+          {featureCards.map((feature) => (
+            <FeatureCard
+              key={feature.title}
+              title={feature.title}
+              description={feature.description}
+            />
+          ))}
+        </div>
+
+        <section className="rounded-3xl border border-slate-200 bg-white/70 p-8 shadow-sm">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-2xl font-semibold text-slate-900">
+                Ready to seed your first watchlist?
+              </h2>
+              <p className="mt-2 text-sm text-slate-600">
+                Use the included seed script to populate demo signals in under a
+                minute.
+              </p>
+            </div>
+            <a
+              className="inline-flex items-center justify-center rounded-full bg-brand-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-700"
+              href="/api/seed"
+            >
+              Preview seed response
+            </a>
+          </div>
+        </section>
+
+        <Footer />
+      </section>
+    </main>
+  );
+}

--- a/components/FeatureCard.tsx
+++ b/components/FeatureCard.tsx
@@ -1,0 +1,13 @@
+interface FeatureCardProps {
+  title: string;
+  description: string;
+}
+
+export function FeatureCard({ title, description }: FeatureCardProps) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+      <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+      <p className="mt-2 text-sm text-slate-600">{description}</p>
+    </div>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,10 @@
+export function Footer() {
+  return (
+    <footer className="mt-16 border-t border-slate-200 py-8 text-sm text-slate-500">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <span>AI FOMO · Signal intelligence for thoughtful teams.</span>
+        <span>Built for Vercel deployments.</span>
+      </div>
+    </footer>
+  );
+}

--- a/components/StatPill.tsx
+++ b/components/StatPill.tsx
@@ -1,0 +1,15 @@
+interface StatPillProps {
+  label: string;
+  value: string;
+}
+
+export function StatPill({ label, value }: StatPillProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-full border border-slate-200 bg-white px-4 py-2 shadow-sm">
+      <span className="text-sm font-semibold text-brand-600">{value}</span>
+      <span className="text-xs uppercase tracking-wide text-slate-500">
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,29 @@
+export const heroHighlights = [
+  "Track trending AI launches",
+  "Monitor confidence signals",
+  "Share curated watchlists"
+];
+
+export const signalStats = [
+  { label: "Signals tracked", value: "128" },
+  { label: "Daily updates", value: "24" },
+  { label: "Curated lists", value: "6" }
+];
+
+export const featureCards = [
+  {
+    title: "Signal radar",
+    description:
+      "Scan across product launches, research releases, and community chatter in one place."
+  },
+  {
+    title: "Confidence scoring",
+    description:
+      "Blend sentiment, velocity, and founder credibility into a single confidence read."
+  },
+  {
+    title: "Decision notebook",
+    description:
+      "Capture why you followed or skipped a signal and learn from the outcome."
+  }
+];

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "ai-fomo",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "postcss": "8.4.39",
+    "tailwindcss": "3.4.7",
+    "typescript": "5.5.4"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/seed/signals.ts
+++ b/seed/signals.ts
@@ -1,0 +1,20 @@
+export const seedSignals = [
+  {
+    id: "signal-001",
+    name: "SynthOps",
+    category: "Agents",
+    confidence: 0.78
+  },
+  {
+    id: "signal-002",
+    name: "VisionOps",
+    category: "Infra",
+    confidence: 0.64
+  },
+  {
+    id: "signal-003",
+    name: "Atlas Labs",
+    category: "Research",
+    confidence: 0.82
+  }
+];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          50: "#eff6ff",
+          100: "#dbeafe",
+          500: "#3b82f6",
+          600: "#2563eb",
+          700: "#1d4ed8"
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal Next.js (App Router) + TypeScript starter scaffold for the AI FOMO product that is ready to deploy on Vercel. 
- Include example UI, seed data, and simple API routes so the app can be previewed and iterated quickly.

### Description
- Add App Router pages and layout with `app/page.tsx`, `app/layout.tsx`, and global styles in `app/globals.css` and font integration. 
- Add example API routes `GET /api/health` and `GET /api/seed` in `app/api/health/route.ts` and `app/api/seed/route.ts` wired to seed data in `seed/signals.ts`. 
- Add reusable UI components `components/FeatureCard.tsx`, `components/StatPill.tsx`, and `components/Footer.tsx` plus static UI data in `lib/data.ts`. 
- Add project config and tooling files including `package.json`, `tsconfig.json`, `next.config.mjs`, `tailwind.config.ts`, `postcss.config.js`, `.eslintrc.json`, `.gitignore`, and `README.md` to enable Tailwind CSS and Vercel deployment.

### Testing
- Attempted dependency install with `npm install` to validate the setup, but it failed with a `403 Forbidden` error from the npm registry so the dev server could not be started. 
- No further automated tests or `next dev` verification were run due to the dependency install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69779c521d4883329c1133f5b563a1d0)